### PR TITLE
Update Chrome webstore URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@
 You may search and install the certain version of **PhotoShow** for your browsers from their extensions (add-ons) web stores (click the icons below):
 
 <p align="center">
-  <a href="https://chrome.google.com/webstore/detail/photoshow/mgpdnhlllbpncjpgokgfogidhoegebod/" title="Google Chrome"><img src="resources/Browser_Chrome.png" alt="Google Chrome" /></a>&emsp;
+  <a href="https://chromewebstore.google.com/detail/photoshow/mgpdnhlllbpncjpgokgfogidhoegebod" title="Google Chrome"><img src="resources/Browser_Chrome.png" alt="Google Chrome" /></a>&emsp;
   <a href="https://addons.mozilla.org/firefox/addon/photoshow/" title="Mozilla Firefox"><img src="resources/Browser_Firefox.png" alt="Mozilla Firefox" /></a>&emsp;
   <a href="https://microsoftedge.microsoft.com/addons/detail/afdelcfalkgcfelngdclbaijgeaklbjk" title="Microsoft Edge"><img src="resources/Browser_Edge.png" alt="Microsoft Edge" /></a>
 </p>

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -25,7 +25,7 @@
 您可以通过各大浏览器应用市场（点击下列图标直达）搜索并安装**浮图秀**：
 
 <p align="center">
-  <a href="https://chrome.google.com/webstore/detail/photoshow/mgpdnhlllbpncjpgokgfogidhoegebod/" title="谷歌 Chrome"><img src="resources/Browser_Chrome.png" alt="谷歌 Chrome" /></a>&emsp;
+  <a href="https://chromewebstore.google.com/detail/photoshow/mgpdnhlllbpncjpgokgfogidhoegebod" title="谷歌 Chrome"><img src="resources/Browser_Chrome.png" alt="谷歌 Chrome" /></a>&emsp;
   <a href="https://addons.mozilla.org/firefox/addon/photoshow/" title="Mozilla 火狐"><img src="resources/Browser_Firefox.png" alt="Mozilla 火狐" /></a>&emsp;
   <a href="https://microsoftedge.microsoft.com/addons/detail/afdelcfalkgcfelngdclbaijgeaklbjk" title="微软 Edge"><img src="resources/Browser_Edge.png" alt="微软 Edge" /></a>
 </p>


### PR DESCRIPTION
The old link in the Readme file was unable to properly redirect to the corresponding extension webpage. It has now been updated to the new link.